### PR TITLE
23 update s3 util to allow for untarred uploading

### DIFF
--- a/dane/s3_util.py
+++ b/dane/s3_util.py
@@ -244,11 +244,12 @@ class S3Store:
             except Exception:
                 logger.exception(f"Failed to download {object_name}")
         else:
-            response = self.client.list_objects(Bucket=bucket, Prefix=object_name)
-            if len(response["Contents"]) == 0:
+            response = self.client.list_objects_v2(Bucket=bucket, Prefix=object_name)
+            if response['KeyCount'] == 0:
                 logger.error(
                     f"No content available in bucket '{bucket}' for prefix '{object_name}'."
                 )
+                success = False
             else:
                 to_download = []
                 while True:
@@ -257,7 +258,7 @@ class S3Store:
                     ]
                     if not response["IsTruncated"]:
                         break
-                    response = self.client.list_objects(
+                    response = self.client.list_objects_v2(
                         Bucket=bucket,
                         Prefix=object_name,
                         Marker=response["Contents"][-1]["Key"],

--- a/dane/s3_util.py
+++ b/dane/s3_util.py
@@ -182,17 +182,9 @@ class S3Store:
         """
         Clean up the prefix in the bucket: delete all keys with the specified prefix.
         """
-        response = self.client.list_objects(Bucket=bucket, Prefix=prefix)
-        if response["KeyCount"] > 0:
+        to_delete = self.list_prefix(bucket=bucket, prefix=prefix)
+        if len(to_delete) > 0:
             logger.warn(f"Prefix '{prefix}' exists in bucket '{bucket}'.")
-            to_delete = []
-            while True:
-                to_delete += [{"Key": item["Key"]} for item in response["Contents"]]
-                if not response["IsTruncated"]:
-                    break
-                response = self.client.list_objects(
-                    Bucket=bucket, Prefix=prefix, Marker=response["Contents"][-1]["Key"]
-                )
             logger.warn(
                 f"Removing {len(to_delete)} item with '{prefix}' as prefix from bucket."
             )

--- a/test/test_s3_util.py
+++ b/test/test_s3_util.py
@@ -1,0 +1,58 @@
+from dane.s3_util import digest_file_list
+import pytest
+import os
+import shutil
+import tarfile
+
+
+@pytest.fixture()
+def tar_archive_paths():
+    paths = ("tmp_tar_for_tests.tar.gz", "tmp_untarred_for_tests")
+    for path in paths:
+        if os.path.exists(path):
+            print("Test path exists. Abort test.")
+            assert False
+    os.makedirs(paths[1])
+    yield paths
+    os.remove(paths[0])
+    shutil.rmtree(paths[1])
+
+
+@pytest.fixture()
+def setup_output_dir():
+    base = "tmp_dir_for_tests"
+    outputtypes = ["provenance", "assets"]
+    for outputtype in outputtypes:
+        os.makedirs(os.path.join(base, outputtype))
+    for fn in [
+        os.path.join(base, "tmp_file_top_level"),
+        os.path.join(base, outputtypes[0], "tmp_file_in_subdir"),
+    ]:
+        with open(fn, "w") as f:
+            f.write("Hello world")
+    yield base
+
+    shutil.rmtree(base)
+
+
+def test_digest_file_list_no_tar(setup_output_dir):
+    prefix = "test-prefix"
+    list_of_files_and_keys = digest_file_list(
+        file_list=[setup_output_dir], prefix=prefix
+    )
+    for f, k in list_of_files_and_keys:
+        assert os.path.isfile(f)
+        assert k.startswith(prefix)
+
+
+def test_digest_file_list_tar(setup_output_dir, tar_archive_paths):
+    tar_archive_path, untarred_archive_path = tar_archive_paths
+    prefix = "test-prefix"
+    list_of_files_and_keys = digest_file_list(
+        file_list=[setup_output_dir], prefix=prefix, tar_archive_path=tar_archive_path
+    )
+    assert len(list_of_files_and_keys) == 1
+    assert os.path.isfile(tar_archive_path)
+    assert list_of_files_and_keys[0][1].startswith(prefix)
+    with tarfile.open(tar_archive_path) as tar:
+        tar.extractall(path=untarred_archive_path, filter="data")  # type: ignore


### PR DESCRIPTION
Updated the s3_util to allow non-tarred output transfer, to enable (for instance) syncing keyframes without having to (un)tar everything. Also makes it easier to link to proper provenance directly. 
For this, created a method to parse the incoming file_list and create proper keys for the contents.

Breaking change for release: changed the return type of s3_download, to obtain provenance of download step from DANE module directly (rather than have each worker implement this). Please check if this makes sense to you. 

Added some docstrings here and there, and put the newly created code under test

For review, please:

- [ ] Run the tests (`poetry install` and then `poetry run pytest`)
- [ ] Review the code in the s3_util
- [ ] Have a look at the unit tests. Are there any obvious cases I missed that really need to be added?
- [ ] Check that it works as expected with a worker using this branch as a dependency (https://github.com/beeldengeluid/dane-video-segmentation-worker/pull/71)
- [ ] What do you think about the return type change for the `s3_download`? I haven't thoroughly tested this (will be used in https://github.com/beeldengeluid/dane-visual-feature-extraction-worker/pull/48)
- [ ] Are there any other concerns? 
